### PR TITLE
Set the default rpc port

### DIFF
--- a/examples/pingo-hello-world/main.go
+++ b/examples/pingo-hello-world/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/dullgiulio/pingo"
 )
 
@@ -15,6 +16,6 @@ func (p *Plugin) SayHello(name string, msg *string) error {
 func main() {
 	plugin := &Plugin{}
 
-	pingo.Register(plugin)
+	pingo.Register(plugin, 10881)
 	pingo.Run()
 }

--- a/server.go
+++ b/server.go
@@ -197,7 +197,7 @@ type tcp int
 func (t *tcp) addr() string {
 	if *t < tcp(defaultServer.fromport) {
 		// Only use unprivileged ports
-		*t = tcp(defaultServer.fromport)
+		*t = tcp(defaultServer.fromport) - 1
 	}
 
 	*t = *t + 1

--- a/server.go
+++ b/server.go
@@ -195,9 +195,9 @@ type connection interface {
 type tcp int
 
 func (t *tcp) addr() string {
-	if *t < 1024 {
+	if *t < tcp(defaultServer.fromport) {
 		// Only use unprivileged ports
-		*t = 1023
+		*t = tcp(defaultServer.fromport)
 	}
 
 	*t = *t + 1
@@ -234,7 +234,7 @@ func (r *rpcServer) run() error {
 
 	switch r.conf.proto {
 	case "tcp":
-		conn = new(tcp(r.fromport))
+		conn = new(tcp)
 	default:
 		r.conf.proto = "unix"
 		conn = new(unix)

--- a/server.go
+++ b/server.go
@@ -26,10 +26,11 @@ import (
 // "rpc" module has to obey.
 //
 // Register will panic if called after Run.
-func Register(obj interface{}) {
+func Register(obj interface{}, fromport int) {
 	if defaultServer.running {
 		panic("Do not call Register after Run")
 	}
+	defaultServer.fromport = fromport
 	defaultServer.register(obj)
 }
 
@@ -72,19 +73,21 @@ func makeConfig() *config {
 
 type rpcServer struct {
 	*rpc.Server
-	secret  string
-	objs    []string
-	conf    *config
-	running bool
+	secret   string
+	objs     []string
+	conf     *config
+	running  bool
+	fromport int
 }
 
 func newRpcServer() *rpcServer {
 	rand.Seed(time.Now().UTC().UnixNano())
 	r := &rpcServer{
-		Server: rpc.NewServer(),
-		secret: randstr(64),
-		objs:   make([]string, 0),
-		conf:   makeConfig(), // conf remains fixed after this point
+		Server:   rpc.NewServer(),
+		secret:   randstr(64),
+		objs:     make([]string, 0),
+		conf:     makeConfig(), // conf remains fixed after this point
+		fromport: 18881,
 	}
 	r.register(&PingoRpc{})
 	return r
@@ -231,7 +234,7 @@ func (r *rpcServer) run() error {
 
 	switch r.conf.proto {
 	case "tcp":
-		conn = new(tcp)
+		conn = new(r.fromport)
 	default:
 		r.conf.proto = "unix"
 		conn = new(unix)

--- a/server.go
+++ b/server.go
@@ -234,7 +234,7 @@ func (r *rpcServer) run() error {
 
 	switch r.conf.proto {
 	case "tcp":
-		conn = new(r.fromport)
+		conn = new(tcp(r.fromport))
 	default:
 		r.conf.proto = "unix"
 		conn = new(unix)


### PR DESCRIPTION
Set the default rpc port
Current the default rpc server port is starting from 1024.
Added one parameter in Register method, client can modify the value to different value